### PR TITLE
Added (optional) poweredby field to config

### DIFF
--- a/lib/data-server.js
+++ b/lib/data-server.js
@@ -129,7 +129,8 @@ function handleRiverStreamsRequest(req, res) {
                     keys: meta,
                     urls: urls,
                     tmpl: {
-                        title: riverName + ' keys'
+                        title: riverName + ' keys',
+                        poweredBy: river.config.poweredBy
                     }
                 }, ext, res, req.query.callback);
             });
@@ -139,7 +140,8 @@ function handleRiverStreamsRequest(req, res) {
                 keys: keys,
                 urls: urls,
                 tmpl: {
-                    title: riverName + ' keys'
+                    title: riverName + ' keys',
+                    poweredBy: river.config.poweredBy
                 }
             }, ext, res, req.query.callback);
         }
@@ -194,7 +196,8 @@ function handleTemporalDataRequest(req, res) {
                         firstData: first.format('YYYY/MM/DD HH:mm:ss'),
                         lastData: last.format('YYYY/MM/DD HH:mm:ss'),
                         lastDataLabel: last.fromNow(),
-                        dataJson: JSON.stringify(dataOut)
+                        dataJson: JSON.stringify(dataOut),
+                        poweredBy: river.config.poweredBy
                     }
                 }, ext, res, req.query.callback);
             });

--- a/site/templates/keys.html
+++ b/site/templates/keys.html
@@ -7,7 +7,7 @@
 </ol>
 
 <div class="page-header">
-  <h1>{{name}} <small><em>streams</em></small></h1>
+  <h1 style="display: inline;">{{name}} <small><em>streams</em></small></h1>{{{tmpl.poweredBy}}}
 </div>
 
 <div class="btn-group" role="group">

--- a/site/templates/partials/data-header.html
+++ b/site/templates/partials/data-header.html
@@ -9,7 +9,7 @@
 
     <div class="col-md-8">
         <div class="jumbotron">
-          <h1>{{ name }}</h1>
+          <h1 style="display: inline;">{{ this.name }}</h1>{{{tmpl.poweredBy}}}
           <h3>{{ id }} <small><em>(<strong>{{type}}</strong> data stream)</em></small></h3>
           <div class="btn-group btn-group-justified" role="group">
               <a class="btn btn-primary btn-lg download" href="data.json" role="button"><span class="glyphicon glyphicon-sunglasses" aria-hidden="true"></span> JSON API</a>

--- a/site/templates/riverMeta.html
+++ b/site/templates/riverMeta.html
@@ -6,7 +6,7 @@
 </ol>
 
 <div class="jumbotron">
-  <h1>{{ this.name }}</h1>
+  <h1 style="display: inline;">{{ this.name }}</h1>{{{this.poweredBy}}}
   <p>{{ this.description }}</p>
 
   <div class="btn-group" role="group">


### PR DESCRIPTION
Fixes #33 

Adds a new field `poweredBy` to config allowing the river to link back to it's original data source.
The poweredBy should be HTML code allowing you to use pre-made links/images to data providers (example using *powered by yahoo*: https://developer.yahoo.com/attribution/) 

(to see an example of this in action pull in https://github.com/jaredweiss/river-view/tree/stock-rivers)
