### PR TITLE
Non-continuous rivers

### DIFF
--- a/lib/data-server.js
+++ b/lib/data-server.js
@@ -107,7 +107,7 @@ function getIntervalName(riverConfig) {
 
 function getIntervalString(riverConfig) {
     return ((riverConfig.hasOwnProperty('cronInterval'))
-             ? ((riverConfig.cronInterval.length == 1) ? "<code>" + riverConfig.cronInterval[0] + "</code>"
+             ? ((typeof riverConfig.cronInterval === 'string') ? "<code>" + riverConfig.cronInterval + "</code>"
                                                        : "<ul><li><code>" + riverConfig.cronInterval.join("</code></li><li><code>") + "</code></li></ul>")
              : riverConfig.interval);
 }

--- a/lib/data-server.js
+++ b/lib/data-server.js
@@ -93,7 +93,23 @@ function handleRiverMetaDataRequest(req, res) {
     // Add email hash for gravatar
     data.tmpl.emailHash = crypto.createHash('md5').update(data.email).digest("hex");
     data.tmpl.title = riverName + ' metadata';
+
+    data.tmpl.intervalName = getIntervalName(data),
+    data.tmpl.intervalString = getIntervalString(data)
+
     renderPage('riverMeta', data, ext, res, req.query.callback);
+}
+
+function getIntervalName(riverConfig) {
+    console.log(riverConfig)
+    return ((riverConfig.hasOwnProperty('cronInterval')) ? "Cron Interval:" : "Collection Interval");
+}
+
+function getIntervalString(riverConfig) {
+    return ((riverConfig.hasOwnProperty('cronInterval'))
+             ? ((riverConfig.cronInterval.length == 1) ? "<code>" + riverConfig.cronInterval[0] + "</code>"
+                                                       : "<ul><li><code>" + riverConfig.cronInterval.join("</code></li><li><code>") + "</code></li></ul>")
+             : riverConfig.interval);
 }
 
 function handleRiverStreamsRequest(req, res) {

--- a/lib/data-server.js
+++ b/lib/data-server.js
@@ -101,7 +101,6 @@ function handleRiverMetaDataRequest(req, res) {
 }
 
 function getIntervalName(riverConfig) {
-    console.log(riverConfig)
     return ((riverConfig.hasOwnProperty('cronInterval')) ? "Cron Interval:" : "Collection Interval");
 }
 

--- a/lib/lockmaster.js
+++ b/lib/lockmaster.js
@@ -1,6 +1,7 @@
 var _ = require('lodash'),
     request = require('request'),
-    moment = require('moment');
+    moment = require('moment'),
+    schedule = require('node-schedule');
 
 /**
  * The Lockmaster handles when River parsers are run, what they are sent, and
@@ -109,10 +110,17 @@ Lockmaster.prototype.start = function start() {
         };
 
         // Start running at intervals.
-        me._running[river] = setInterval(riverRunner, intervalSeconds);
+        if (river.config.hasOwnProperty('cronInterval')) {
+            _.each(river.config.cronInterval, function(interval) {
+                schedule.scheduleJob(interval, riverRunner);
+            });
+        } else {
+            me._running[river] = setInterval(riverRunner, intervalSeconds);
 
-        // Run once now at startup.
-        riverRunner();
+            // Run once now at startup.
+            riverRunner();
+        }
+
     });
 };
 

--- a/lib/lockmaster.js
+++ b/lib/lockmaster.js
@@ -111,9 +111,13 @@ Lockmaster.prototype.start = function start() {
 
         // Start running at intervals.
         if (river.config.hasOwnProperty('cronInterval')) {
-            _.each(river.config.cronInterval, function(interval) {
-                schedule.scheduleJob(interval, riverRunner);
-            });
+            if (typeof river.config.cronInterval === 'string') {
+                schedule.scheduleJob(river.config.cronInterval);
+            } else {
+                _.each(river.config.cronInterval, function(interval) {
+                    schedule.scheduleJob(interval, riverRunner);
+                });
+            }
         } else {
             me._running[river] = setInterval(riverRunner, intervalSeconds);
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "moment": "^2.10.3",
     "moment-timezone": "^0.4.0",
     "node-geocoder": "^2.21.2",
+    "node-schedule": "^0.2.9",
     "redis": "^0.12.1",
     "request": "^2.58.0",
     "xml2js": "^0.4.9"

--- a/site/templates/riverMeta.html
+++ b/site/templates/riverMeta.html
@@ -43,8 +43,8 @@
                 <div class="panel panel-default">
                     <div class="panel-body">
                         <dl>
-                            <dt>Collection Interval</dt>
-                            <dd>{{interval}}</dd>
+                            <dt>{{tmpl.intervalName}}</dt>
+                            <dd>{{{tmpl.intervalString}}}</dd>
                         </dl>
                         <dl>
                             <dt>Data Expires After</dt>


### PR DESCRIPTION
Fixes #30 

Implements cron-style river parsing. Use a `cronInterval` rather than a regular `interval` in the river spec to specify advanced parsing. `cronInterval` supports lists of intervals to account for special cases. 