### PR TITLE
twitter_earthquake - push only new data

### DIFF
--- a/rivers/twitter_earthquake/parser.js
+++ b/rivers/twitter_earthquake/parser.js
@@ -186,7 +186,7 @@ module.exports = function(body, options, temporalDataCallback, metaDataCallback)
                 if (parseInt(moreData.timestamp) === lastTimestamp) {
                     return;
                 } else {
-                temporalDataCallback(id, parseInt(moreData.timestamp), fieldValues);
+                    temporalDataCallback(id, parseInt(moreData.timestamp), fieldValues);
                 }
             });
         } else {
@@ -202,7 +202,7 @@ module.exports = function(body, options, temporalDataCallback, metaDataCallback)
             if (parseInt(timestamp) === lastTimestamp) {
                 return;
             } else {
-            temporalDataCallback(id, parseInt(timestamp), fieldValues);
+                temporalDataCallback(id, parseInt(timestamp), fieldValues);
             }
         }
     });

--- a/rivers/twitter_earthquake/parser.js
+++ b/rivers/twitter_earthquake/parser.js
@@ -1,15 +1,5 @@
 /*
-Structures: 
-
-Powerful earthquake,
-NEPAL,
-Apr-26 07:09 UTC,
-24 #quake tweets/min, 
-http://on.doi.gov/1b32DdF 
- 
-[Deprected; only until 26. Apr. 2015]
-
-Currently: 
+Structure: 
 
 Prelim M6.2 earthquake FIJI REGION Apr-28 16:39 UTC, updates http://on.doi.gov/1P3449l , 0 #quake tweets/min
 
@@ -127,13 +117,15 @@ function fetchMoreDataFrom(url, callback) {
 
         out['descriptionAndLinks'] = event_content; 
 
-
         callback(null, out);
     });
 }
 
-module.exports = function(config, body, url, temporalDataCallback, metaDataCallback) {
-    var $ = cheerio.load(body),
+module.exports = function(body, options, temporalDataCallback, metaDataCallback) {
+    var config = options.config, 
+        url = options.url,
+        lastTimestamp = options.lastTimestamp,
+        $ = cheerio.load(body),
         columnNames = [],
         id = 'twitter_earthquake';
 
@@ -190,7 +182,12 @@ module.exports = function(config, body, url, temporalDataCallback, metaDataCallb
                 if (moreData.timestamp === NaN) {
                     moreData.timestamp = parseTimeString(timeMatch, timestamp_posting);
                 }
+                // only push new data!
+                if (parseInt(moreData.timestamp) === lastTimestamp) {
+                    return;
+                } else {
                 temporalDataCallback(id, parseInt(moreData.timestamp), fieldValues);
+                }
             });
         } else {
             var timeMatch, magnitude, timestamp;
@@ -201,7 +198,12 @@ module.exports = function(config, body, url, temporalDataCallback, metaDataCallb
             magnitude = parseFloat(text.split(' ')[1].replace('M', ''));
 
             fieldValues = fieldValues.concat([timestamp, magnitude, null, null, null, null, null, null, null]);
+            // only push new data!
+            if (parseInt(timestamp) === lastTimestamp) {
+                return;
+            } else {
             temporalDataCallback(id, parseInt(timestamp), fieldValues);
+            }
         }
     });
 };


### PR DESCRIPTION
fails the river-test.js: 

```
  river parser
    ✓ parse script exports a function
    when passed a live response body
      1) calls the temporalDataCallback with data matching config
      2) calls the metadataCallback with JSON-parseable data


  13 passing (900ms)
  2 failing

  1) river parser when passed a live response body calls the temporalDataCallback with data matching config:
     TypeError: Cannot read property 'timezone' of undefined
      at module.exports (rivers/twitter_earthquake/parser.js:133:32)
      at test/rivers/river-tests.js:138:21
      at Context.<anonymous> (test/rivers/river-tests.js:151:19)

  2) river parser when passed a live response body calls the metadataCallback with JSON-parseable data:
     TypeError: Cannot read property 'timezone' of undefined
      at module.exports (rivers/twitter_earthquake/parser.js:133:32)
      at test/rivers/river-tests.js:162:21
      at Context.<anonymous> (test/rivers/river-tests.js:172:19)

```