### PR TITLE
Increase test timeout for multiple URL sources.

### DIFF
--- a/test/rivers/river-tests.js
+++ b/test/rivers/river-tests.js
@@ -91,6 +91,12 @@ describe('river config', function() {
 
     it('sources all resolve to working URLs', function(done) {
         var fetchers = {};
+        var me = this;
+
+        // Each source URL needs time for the HTTP call to respond. We will
+        // increase the callback for each source.
+        me.timeout(TIMEOUT * config.sources.length);
+
         _.each(config.sources, function(sourceUrl) {
             fetchers[sourceUrl] = function(callback) {
                 request.get(sourceUrl, function(err, resp, body) {


### PR DESCRIPTION
This change increases the timeout if there are many URL sources, because
each one needs time to get an HTTP response back.

This PR was created so that #50 would pass tests.