### PR TITLE
Added river initialization.

### DIFF
--- a/lib/lockmaster.js
+++ b/lib/lockmaster.js
@@ -1,7 +1,10 @@
 var _ = require('lodash'),
     request = require('request'),
     moment = require('moment'),
-    schedule = require('node-schedule');
+    async = require('async'),
+    schedule = require('node-schedule'),
+    riverUtils = require('./river-utilities')
+    ;
 
 /**
  * The Lockmaster handles when River parsers are run, what they are sent, and
@@ -22,6 +25,28 @@ function Lockmaster(opts) {
     this._running = {};
 }
 
+Lockmaster.prototype.makeRequest = function(url, callback) {
+    // If the url ends with ".gz", treat it as a gzipped file.
+    if (_.endsWith(url, '.gz')) {
+        riverUtils.gZippedPathToString(url, callback);
+    } else {
+        request.get(url, callback);
+    }
+};
+
+Lockmaster.prototype.initializeRivers = function(callback) {
+    var initializers = [];
+    _.each(this.rivers, function(r) {
+        if (r.initialize && typeof r.initialize == 'function') {
+            console.log('Initializing River "' + r.name + '"...');
+            initializers.push(function(localCallback) {
+                r.initialize(localCallback);
+            });
+        }
+    });
+    async.parallel(initializers, callback);
+};
+
 /**
  * When called, the Lockmaster wills start start running Rivers given the
  * `interval` setting in the River's config.yml file. It will run each river's
@@ -35,102 +60,112 @@ function Lockmaster(opts) {
 Lockmaster.prototype.start = function start() {
     var me = this;
 
-    _.each(me.rivers, function(river) {
-        var interval = river.config.interval.split(/\s+/),
-            intervalValue = parseInt(interval.shift()),
-            intervalUnits = interval.shift(),
-            duration = moment.duration(intervalValue, intervalUnits),
-            intervalSeconds = duration.asMilliseconds(),
-            riverName = river.config.name,
-            riverRunner;
+    me.initializeRivers(function(err) {
+        if (err) {
+            throw err;
+        }
+        _.each(me.rivers, function(river) {
+            var interval = river.config.interval.split(/\s+/),
+                intervalValue = parseInt(interval.shift()),
+                intervalUnits = interval.shift(),
+                duration = moment.duration(intervalValue, intervalUnits),
+                intervalSeconds = duration.asMilliseconds(),
+                riverName = river.config.name,
+                riverRunner;
 
-        me.redisClient.logObject({
-            level: 'info',
-            river: riverName,
-            message: 'Starting river "' + riverName + '", which will run every ' +
-            river.config.interval + '.'
-        });
+            me.redisClient.logObject({
+                level: 'info',
+                river: riverName,
+                message: 'Starting river "' + riverName + '", which will run every ' +
+                river.config.interval + '.'
+            });
 
-        riverRunner = function() {
-            var config = river.config;
-            console.log('Initializing River "' + config.name + '"...');
-            _.each(config.sources, function(url) {
-                console.log('Making %s request to\n\t%s', riverName, url);
-                me.redisClient.logObject({
-                    level: 'info',
-                    river: riverName,
-                    message: 'request made to ' + url
-                });
-                request.get(url, function(err, resp, body) {
-                    var options = {};
-                    if (err) {
-                        console.error(err);
-                        me.redisClient.logObject({
-                            level: 'warn',
-                            river: riverName,
-                            message: 'HTTP error from ' + url + ': ' + err.message
-                        });
-                        return;
-                    }
-                    console.log('Received %s response from \n\t%s', riverName, url);
+            riverRunner = function() {
+                var config = river.config;
+                _.each(config.sources, function(url) {
+                    console.log('Making %s request to\n\t%s', riverName, url);
                     me.redisClient.logObject({
                         level: 'info',
                         river: riverName,
-                        message: 'response ' + resp.statusCode + ' received from ' + url
+                        message: 'request made to ' + url
                     });
 
-                    // Set up the options object we'll be sending to all parsers.
-                    options.config = config;
-                    options.url = url;
-                    try {
-                        // pass response body into parser
-                        river.parse.call(
-                            // We are not going to pass the parse function any
-                            // context, that means that "this" will be undefined.
-                            undefined,
-                            // response body from HTTP call to source URL
-                            body,
-                            // Options object containing all additional info like
-                            // config and url and whatever else we want to send in
-                            // the future.
-                            options,
-                            // Callback for data with a timestamp.
-                            function() {
-                                river.saveTemporalData.apply(river, arguments);
-                            },
-                            // Callback for metadata.
-                            function() {
-                                river.saveMetaData.apply(river, arguments);
-                            }
-                        );
-                    } catch (parseError) {
+                    function requestCallback(err, resp, body) {
+                        var options = {};
+                        if (err) {
+                            console.error(err);
+                            me.redisClient.logObject({
+                                level: 'warn',
+                                river: riverName,
+                                message: 'HTTP error from ' + url + ': ' + err.message
+                            });
+                            return;
+                        }
+                        console.log('Received %s response from \n\t%s', riverName, url);
                         me.redisClient.logObject({
-                            level: 'warn',
+                            level: 'info',
                             river: riverName,
-                            message: parseError.message
+                            message: 'response ' + resp.statusCode + ' received from ' + url
                         });
+
+                        // Set up the options object we'll be sending to all parsers.
+                        options.config = config;
+                        options.url = url;
+                        try {
+                            // pass response body into parser
+                            river.parse.call(
+                                // We are not going to pass the parse function any
+                                // context, that means that "this" will be undefined.
+                                undefined,
+                                // response body from HTTP call to source URL
+                                body,
+                                // Options object containing all additional info like
+                                // config and url and whatever else we want to send in
+                                // the future.
+                                options,
+                                // Callback for data with a timestamp.
+                                function() {
+                                    river.saveTemporalData.apply(river, arguments);
+                                },
+                                // Callback for metadata.
+                                function() {
+                                    river.saveMetaData.apply(river, arguments);
+                                }
+                            );
+                        } catch (parseError) {
+                            me.redisClient.logObject({
+                                level: 'warn',
+                                river: riverName,
+                                message: parseError.message
+                            });
+                        }
                     }
-                });
-            });
-        };
 
-        // Start running at intervals.
-        if (river.config.hasOwnProperty('cronInterval')) {
-            if (typeof river.config.cronInterval === 'string') {
-                schedule.scheduleJob(river.config.cronInterval);
+                    me.makeRequest(url, requestCallback);
+
+                });
+            };
+
+            // Start running at intervals.
+            if (river.config.hasOwnProperty('cronInterval')) {
+                if (typeof river.config.cronInterval === 'string') {
+                    schedule.scheduleJob(river.config.cronInterval);
+                } else {
+                    _.each(river.config.cronInterval, function(interval) {
+                        schedule.scheduleJob(interval, riverRunner);
+                    });
+                }
             } else {
-                _.each(river.config.cronInterval, function(interval) {
-                    schedule.scheduleJob(interval, riverRunner);
-                });
-            }
-        } else {
-            me._running[river] = setInterval(riverRunner, intervalSeconds);
+                me._running[river] = setInterval(riverRunner, intervalSeconds);
 
-            // Run once now at startup.
-            riverRunner();
-        }
+                // Run once now at startup.
+                riverRunner();
+            }
+
+        });
 
     });
+
 };
 
 module.exports = Lockmaster;

--- a/lib/river-factory.js
+++ b/lib/river-factory.js
@@ -13,7 +13,8 @@ var fs = require('fs'),
     DEFAULT_EXPIRES = '6 months';
 
 function createRiver(redisClient, absPath, riverDirectory, riverName) {
-    var configPath, config, requirePath, parseFunction, files = fs.readdirSync(absPath);
+    var configPath, config, requirePath, riverModule,
+        parseFunction, initFunction, files = fs.readdirSync(absPath);
     // Process config file.
     if (!_.contains(files, configFileName)) {
         throw new Error('River "' + riverName + '" is missing ' + configFileName);
@@ -28,7 +29,15 @@ function createRiver(redisClient, absPath, riverDirectory, riverName) {
         throw new Error('River "' + riverName + '" is missing ' + parserFileName);
     }
     requirePath = path.join('..', riverDirectory, riverName) + '/' + parserFileName.split('.')[0];
-    parseFunction = require(requirePath);
+    riverModule = require(requirePath);
+
+    if (typeof riverModule == 'function') {
+        parseFunction = riverModule;
+    } else {
+        parseFunction = riverModule.parse;
+        initFunction = riverModule.initialize;
+    }
+
     // Set default interval and expires.
     // TODO: This should be set in a separate file that contains all default
     //       river settings
@@ -41,7 +50,8 @@ function createRiver(redisClient, absPath, riverDirectory, riverName) {
     return new River({
         config: config,
         redisClient: redisClient,
-        parser: parseFunction
+        initialize: initFunction,
+        parse: parseFunction
     });
 }
 

--- a/lib/river-utilities.js
+++ b/lib/river-utilities.js
@@ -1,0 +1,70 @@
+var zlib = require('zlib'),
+    request = require('request'),
+    AdmZip = require('adm-zip');
+
+
+function zippedPathToString(pathToZip, callback) {
+    var data = [],
+        dataLen = 0;
+
+    request.get({
+        url: pathToZip,
+        encoding: null
+    }).on('error', function(err) {
+        callback(err)
+    }).on('data', function(chunk) {
+        data.push(chunk);
+        dataLen += chunk.length;
+    }).on('end', function() {
+        var buf = new Buffer(dataLen),
+            i = 0,
+            len, pos, zip, zipEntries;
+
+        for (i = 0, len = data.length, pos = 0; i < len; i++) {
+            data[i].copy(buf, pos);
+            pos += data[i].length;
+        }
+        zip = new AdmZip(buf);
+        zipEntries = zip.getEntries();
+
+        for (i = 0; i < zipEntries.length; i++) {
+            callback(null, zip.readAsText(zipEntries[i]));
+        }
+    });
+}
+
+function gZippedPathToString(pathToGzip, callback) {
+    var data = [];
+    var dataLen = 0;
+    var headers = {
+        'Accept-Encoding': 'gzip'
+    };
+    var response;
+
+    request({
+        url:pathToGzip, 'headers': headers
+    }, function(err, resp) {
+        if (err) {
+            return callback(err);
+        }
+        response = resp;
+    })
+    .pipe(zlib.createGunzip())
+    .on('data', function(chunk) {
+        data.push(chunk);
+        dataLen += chunk.length;
+    })
+    .on('end', function() {
+        var buf = new Buffer(dataLen), i = 0, len, pos;
+        for (i = 0, len = data.length, pos = 0; i < len; i++) {
+            data[i].copy(buf, pos);
+            pos += data[i].length;
+        }
+        callback(null, response, buf.toString());
+    });
+}
+
+module.exports = {
+    zippedPathToString: zippedPathToString,
+    gZippedPathToString: gZippedPathToString
+};

--- a/lib/river.js
+++ b/lib/river.js
@@ -14,7 +14,8 @@ function River(opts) {
     this.config = opts.config;
     this.name = this.config.name;
     this.redisClient = opts.redisClient;
-    this.parse = opts.parser;
+    this.initialize = opts.initialize;
+    this.parse = opts.parse;
     expires = this.config.expires.split(/\s+/);
     expiresValue = parseInt(expires.shift());
     expiresUnits = expires.shift();

--- a/rivers/ercot-demand/parser.js
+++ b/rivers/ercot-demand/parser.js
@@ -2,11 +2,10 @@
 var fs = require('fs'),
     nodeUrl = require('url'),
     http = require('http'),
-    request = require('request'),
     _ = require('lodash'),
+    riverUtils = require('../../lib/river-utilities'),
     csvParse = require('csv-parse'),
     async = require('async'),
-    AdmZip = require('adm-zip'),
     moment = require('moment-timezone'),
     cheerio = require('cheerio');
 
@@ -28,39 +27,6 @@ function dateStringToTimestampWithZone(dateString, timeString, zone) {
     return timestamp;
 }
 
-function unzipToString(pathToZip, callback) {
-    var data = [],
-        dataLen = 0;
-
-    request.get({
-        url: pathToZip,
-        encoding: null
-    })
-        .on('error', function(err) {
-            callback(err)
-        })
-        .on('data', function(chunk) {
-            data.push(chunk);
-            dataLen += chunk.length;
-        })
-        .on('end', function() {
-            var buf = new Buffer(dataLen),
-                i = 0,
-                len, pos, zip, zipEntries;
-
-            for (i = 0, len = data.length, pos = 0; i < len; i++) {
-                data[i].copy(buf, pos);
-                pos += data[i].length;
-            }
-            zip = new AdmZip(buf);
-            zipEntries = zip.getEntries();
-
-            for (i = 0; i < zipEntries.length; i++)
-                callback(null, zip.readAsText(zipEntries[i]));
-        });
-
-}
-
 function systemWideDemand(body, options, temporalDataCallback, metaDataCallback) {
     var config = options.config,
         url = options.url,
@@ -77,10 +43,10 @@ function systemWideDemand(body, options, temporalDataCallback, metaDataCallback)
         var $tr = $(tr),
             href, downloadUrl, fileName = $tr.find('td.labelOptional_ind').html();
         if (_.endsWith(fileName, 'csv.zip')) {
-            href = $tr.find('td:nth-child(4) a').attr('href')
+            href = $tr.find('td:nth-child(4) a').attr('href');
             downloadUrl = sourceDomain + href;
             downloaders.push(function(callback) {
-                unzipToString(downloadUrl, function(err, csvContents) {
+                riverUtils.zippedPathToString(downloadUrl, function(err, csvContents) {
                     if (err) {
                         return console.error(err);
                     }
@@ -90,7 +56,8 @@ function systemWideDemand(body, options, temporalDataCallback, metaDataCallback)
                         if (err) {
                             return console.error(err);
                         }
-                        var headers = data.shift()
+                        // remove headers
+                        data.shift();
                         _.each(data, function(row) {
                             var dateString = row[0],
                                 timeString = row[1],


### PR DESCRIPTION
River scripts can now export either a function (assumed to be the parser
function) or an object:

```javascript
{ parse: function(...) {},
  initialize: function(callback) {} }
```

The `initialize` function will be called on application startup, and
allows rivers to do any required asynchronous processing before the
application is fully running.