### PR TITLE
Changed cron implementation to use timezones and updated river-tests for cron intervals

### DIFF
--- a/lib/lockmaster.js
+++ b/lib/lockmaster.js
@@ -2,7 +2,7 @@ var _ = require('lodash'),
     request = require('request'),
     moment = require('moment'),
     async = require('async'),
-    schedule = require('node-schedule'),
+    CronJob = require('cron').CronJob;
     riverUtils = require('./river-utilities')
     ;
 
@@ -149,10 +149,10 @@ Lockmaster.prototype.start = function start() {
             // Start running at intervals.
             if (river.config.hasOwnProperty('cronInterval')) {
                 if (typeof river.config.cronInterval === 'string') {
-                    schedule.scheduleJob(river.config.cronInterval);
+                    new CronJob(river.config.cronInterval, riverRunner, null, true, river.config.timezone);
                 } else {
                     _.each(river.config.cronInterval, function(interval) {
-                        schedule.scheduleJob(interval, riverRunner);
+                        new CronJob(interval, riverRunner, null, true, river.config.timezone);
                     });
                 }
             } else {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "adm-zip": "^0.4.7",
     "async": "^1.2.1",
     "cheerio": "^0.19.0",
+    "cron": "^1.0.9",
     "csv-parse": "^0.1.3",
     "css-select": "1.0.0",
     "dom-serializer": "^0.1.0",
@@ -47,7 +48,6 @@
     "moment": "^2.10.3",
     "moment-timezone": "^0.4.0",
     "node-geocoder": "^2.21.2",
-    "node-schedule": "^0.2.9",
     "redis": "^0.12.1",
     "request": "^2.58.0",
     "xml2js": "^0.4.9"


### PR DESCRIPTION
Since `node-schedule` doesn't support using external timezones, I switched to using `cron`. Also updated the river-tests to validate cron intervals in addition to regular intervals. 

@rhyolight please review when you get a chance