### PR TITLE
Updated timestamp parsing in yahoo-finance rivers

### DIFF
--- a/rivers/yahoo-finance-prices/parser.js
+++ b/rivers/yahoo-finance-prices/parser.js
@@ -15,9 +15,8 @@ module.exports = function(body, options, temporalDataCallback, metaDataCallback)
 
     moment.tz.setDefault(config.timezone);
 
-    date = moment(dateString + ' ' + timeString, 'YYYY-MM-DD HH:mm:ss');
+    date = moment.tz(dateString + ' ' + timeString, 'YYYY-MM-DD HH:mm:ss', 'UTC'); // The returned timestamp is in UTC
     timestamp = date.unix();
-    res =
 
     fieldValues = [
         parseFloat(res.Ask), parseFloat(res.Bid), parseFloat(res.Change), parseFloat(res.LastTradePriceOnly), parseFloat(res.LastTradePriceOnly)

--- a/rivers/yahoo-finance-stats/parser.js
+++ b/rivers/yahoo-finance-stats/parser.js
@@ -17,7 +17,7 @@ module.exports = function(body, options, temporalDataCallback, metaDataCallback)
 
     moment.tz.setDefault(config.timezone);
 
-    date = moment(dateString + ' ' + timeString, 'YYYY-MM-DD HH:mm:ss');
+    date = moment.tz(dateString + ' ' + timeString, 'YYYY-MM-DD HH:mm:ss', 'UTC'); // The returned timestamp is in UTC
     timestamp = date.unix();
 
     if (_.contains(ebitdaStr, 'M')) {


### PR DESCRIPTION
Fixes #91 

Since the returned timestamp is in UTC, it needs to be converted to the default timestamp by using `moment.tz(...)`.

(Also removes an unnecessary line I must have missed during the code review.)