### PR TITLE
Sending earliest data date to init funcs.

### DIFF
--- a/lib/lockmaster.js
+++ b/lib/lockmaster.js
@@ -35,19 +35,28 @@ Lockmaster.prototype.makeRequest = function(url, callback) {
 };
 
 Lockmaster.prototype.initializeRivers = function(callback) {
-    var initializers = {},
+    var redisClient = this.redisClient,
+        initializers = {},
         initializationFailures = {};
     _.each(this.rivers, function(r) {
         if (! r.config.disabled && r.initialize && typeof r.initialize == 'function') {
-            console.log('Initializing River "' + r.name + '"...');
-            initializers[r.name] = function(localCallback) {
-                r.initialize(r.config, function(err, sourceUrls) {
-                    if (err) {
-                        initializationFailures[r.name] = err;
-                    }
-                    localCallback(null, sourceUrls);
-                });
-            };
+
+            redisClient.getEarliestTimestampForRiver(r.name, function(err, ts) {
+                console.log('Initializing River "' + r.name + '"...');
+                initializers[r.name] = function(localCallback) {
+                    r.initialize({
+                        config: r.config,
+                        lastUpdated: moment.unix(ts)
+                    }, function(err, sourceUrls) {
+                        if (err) {
+                            initializationFailures[r.name] = err;
+                        }
+                        localCallback(null, sourceUrls);
+                    });
+                };
+
+            });
+
         }
     });
     async.parallel(initializers, function(err, sourceUrls) {

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -1,7 +1,8 @@
 var url = require('url'),
     moment = require('moment'),
     redis = require('redis'),
-    _ = require('lodash');
+    _ = require('lodash'),
+    async = require('async');
 
 /*
  * Redis sorted set data comes back "WITHSCORES" in every other array element.
@@ -222,7 +223,7 @@ RedisClient.prototype.getRiverData =
  * @param extreme {string} Either 'earliest' or 'latest'
  * @param callback {function} handles response
  */
-RedisClient.prototype.getExtremeTimestampForRiverData =
+RedisClient.prototype.getExtremeTimestampForRiverStream =
     function getExtremeTimestampForRiverData(riverName, streamId, extreme, callback) {
         var key, since = '-inf',
             until = '+inf',
@@ -255,9 +256,9 @@ RedisClient.prototype.getExtremeTimestampForRiverData =
  * @param streamId {string} Stream id
  * @param callback {function} handles response
  */
-RedisClient.prototype.getLatestTimestampForRiverData =
+RedisClient.prototype.getLatestTimestampForRiverStream =
     function getLatestTimestampForRiverData(riverName, streamId, callback) {
-        this.getExtremeTimestampForRiverData(riverName, streamId, 'latest', callback);
+        this.getExtremeTimestampForRiverStream(riverName, streamId, 'latest', callback);
     };
 
 /**
@@ -266,9 +267,53 @@ RedisClient.prototype.getLatestTimestampForRiverData =
  * @param streamId {string} Stream id
  * @param callback {function} handles response
  */
-RedisClient.prototype.getEarliestTimestampForRiverData =
+RedisClient.prototype.getEarliestTimestampForRiverStream =
     function getEarliestTimestampForRiverData(riverName, streamId, callback) {
-        this.getExtremeTimestampForRiverData(riverName, streamId, 'earliest', callback);
+        this.getExtremeTimestampForRiverStream(riverName, streamId, 'earliest', callback);
+    };
+
+RedisClient.prototype.getEarliestTimestampForRiver =
+    function getEarliestTimestampForRiver(riverName, callback) {
+        var me = this, since = '+inf',
+            until = '-inf',
+            limit = 1,
+            redisFunctionName = 'zrangebyscore',
+            fetchArgs;
+
+        me.client.keys(riverName + ':*:data', function(err, keys) {
+            var fetchers = {};
+
+            _.each(keys, function(key) {
+
+                fetchers[key] = function(localCallback) {
+                    fetchArgs = [key, until, since, 'WITHSCORES', 'LIMIT', 0, limit];
+
+                    me.client[redisFunctionName](fetchArgs, function(error, values) {
+                        var timestamp;
+                        if (error) return callback(error);
+                        // Score is 2nd.
+                        timestamp = values[1];
+                        localCallback(null, timestamp);
+                    });
+                };
+
+            });
+
+            async.parallel(fetchers, function(err, data) {
+                if (err) return callback(err);
+                // Get the earliest updated date
+                var earliest = undefined;
+                _.each(data, function(ts) {
+                    if (earliest == undefined) {
+                        earliest = ts;
+                    } else if (ts < earliest) {
+                        earliest = ts;
+                    }
+                });
+                callback(null, earliest);
+            });
+        });
+
     };
 
 /**

--- a/lib/river.js
+++ b/lib/river.js
@@ -115,12 +115,12 @@ River.prototype.getFirstAndLastUpdatedTimes = function(streamId, callback) {
     var me = this,
         riverName = me.name,
         timezone = me.config.timezone;
-    me.redisClient.getLatestTimestampForRiverData(riverName, streamId, function(err, timestamp) {
+    me.redisClient.getLatestTimestampForRiverStream(riverName, streamId, function(err, timestamp) {
         var latest;
         if (err) return callback(err);
         latest = moment.unix(timestamp).tz(timezone);
 
-        me.redisClient.getEarliestTimestampForRiverData(riverName, streamId, function(err, timestamp) {
+        me.redisClient.getEarliestTimestampForRiverStream(riverName, streamId, function(err, timestamp) {
             var earliest;
             if (err) return callback(err);
             earliest = moment.unix(timestamp).tz(timezone);

--- a/rivers/airnow/parser.js
+++ b/rivers/airnow/parser.js
@@ -58,8 +58,9 @@ function dateStringToTimestampWithZone(timeIn) {
     return timestamp;
 }
 
-function initialize(config, callback) {
-    var urls = [],
+function initialize(options, callback) {
+    var config = options.config,
+        urls = [],
         // As of today (Sep 7, 2015), there are 788 RSS feeds.
         feedCount = 788;
     _.times(feedCount, function(index) {

--- a/rivers/chicago-311/parser.js
+++ b/rivers/chicago-311/parser.js
@@ -53,6 +53,11 @@ module.exports = function(body, options, temporalDataCallback, metaDataCallback)
             return;
         }
 
+        // Skip records with no location.
+        if (! point.location) {
+            return;
+        }
+
         var streamId = lookup[urlId],
             timestamp,
             fieldValues,

--- a/rivers/mn-traffic-sensors/parser.js
+++ b/rivers/mn-traffic-sensors/parser.js
@@ -7,7 +7,7 @@ var _ = require('lodash'),
     detectorMap = {},
     detectorToStation = {};
 
-function getStationDetails(config, callback) {
+function getStationDetails(options, callback) {
     riverUtils.gZippedPathToString(stationsUrl, function(error, resp, xml) {
         if (error) {
             return callback(error);

--- a/test/lib/lockmaster-tests.js
+++ b/test/lib/lockmaster-tests.js
@@ -15,7 +15,7 @@ describe('when initializing a river', function() {
         });
         var barParseCalled = false;
         var mockRiverInitFail = {
-            initialize: function(config, callback) {
+            initialize: function(options, callback) {
                 callback(new Error('oh noes!'));
             },
             parse: function() {
@@ -30,7 +30,7 @@ describe('when initializing a river', function() {
             }
         };
         var mockRiverInitPass = {
-            initialize: function(config, callback) {
+            initialize: function(options, callback) {
                 callback();
             },
             parse: function() {
@@ -47,7 +47,10 @@ describe('when initializing a river', function() {
             config: {},
             rivers: [mockRiverInitFail, mockRiverInitPass],
             redisClient: {
-                logObject: function() {}
+                logObject: function() {},
+                getEarliestTimestampForRiver: function(name, cb) {
+                    cb(null, 0);
+                }
             }
         });
 
@@ -69,7 +72,7 @@ describe('when initializing a river', function() {
             }
         });
         var mockRiver = {
-            initialize: function(config, callback) {
+            initialize: function(options, callback) {
                 callback(null, ['url1', 'url2', 'url3']);
             },
             parse: function() {
@@ -85,7 +88,10 @@ describe('when initializing a river', function() {
             config: {},
             rivers: [mockRiver],
             redisClient: {
-                logObject: function() {}
+                logObject: function() {},
+                getEarliestTimestampForRiver: function(name, cb) {
+                    cb(null, 0);
+                }
             }
         });
 

--- a/test/rivers/river-tests.js
+++ b/test/rivers/river-tests.js
@@ -203,7 +203,7 @@ describe('river initializer / parser', function() {
         if (typeof riverModule != 'function') {
             initialize = riverModule.initialize;
             if (! config.sources) {
-                initialize(config, function(err, sources) {
+                initialize({config: config}, function(err, sources) {
                     assert.ok(sources, 'config.yml is missing "sources" and initializer does not return any');
                     expect(sources).to.be.instanceOf(Array, '"sources" must be an array of URLs.');
                     done();
@@ -222,6 +222,11 @@ describe('river initializer / parser', function() {
         var metadataCallbacks = [];
         var riverModule = require(requirePath);
         var parse, initialize;
+        var mockRedisClient = {
+            getEarliestTimestampForRiver: function(name, cb) {
+                cb(null, 0);
+            }
+        };
 
         if (typeof riverModule != 'function') {
             parse = riverModule.parse;
@@ -235,7 +240,7 @@ describe('river initializer / parser', function() {
             parse: parse,
             name: 'foo',
             config: {}
-        }]});
+        }], redisClient: mockRedisClient});
 
         it('calls the temporalDataCallback with data matching config', function(done) {
             lockmaster.initializeRivers(function(err, sourceUrls) {


### PR DESCRIPTION
If a parser provides an init function, the lockmaster will not query
redis to get the date of the earliest data in the DB, so the initializer
will know if it needs to fetch some historical data.